### PR TITLE
Jsaraceno/media credits a11y fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/content",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React UI library to use with Healthwise structured content API.",
   "main": "index.js",
   "unpkg": "healthwise-structured-content-ui.js",

--- a/src/Credits/index.js
+++ b/src/Credits/index.js
@@ -40,8 +40,10 @@ class Credits extends Component {
         secondaryReviewers.push(reviewer.name)
       })
 
+    const creditsClass = 'hw-structured-content-credits'
+
     return (
-      <div className={className + ' hw-structured-content-credits'} {...otherAttributes}>
+      <div className={className ? (className + ' ' + creditsClass) : creditsClass} {...otherAttributes}>
         {asOfDate ? (
           <P>
             <Span>{currentLabel}:</Span> {asOfDate}
@@ -73,7 +75,7 @@ Credits.defaultProps = {
   currentLabel: 'Current as of',
   authorLabel: 'Author',
   reviewLabel: 'Medical Review',
-  className: '',
+  className: null,
 }
 
 Credits.propTypes = {

--- a/src/Credits/index.js
+++ b/src/Credits/index.js
@@ -73,6 +73,7 @@ Credits.defaultProps = {
   currentLabel: 'Current as of',
   authorLabel: 'Author',
   reviewLabel: 'Medical Review',
+  className: '',
 }
 
 Credits.propTypes = {

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -24,13 +24,10 @@ const DivNavWrapper = styled.div`
   justify-content: space-between;
 `
 
-const NavUl = styled.ul`
+const NavButtonsRow = styled.div`
   margin: 0;
   padding: 0;
-
-  & li {
-    display: inline-block;
-  }
+  display: flex;
 
   @media screen and (-ms-high-contrast: active) {
     background: #fff;
@@ -325,13 +322,32 @@ class MediaCredits extends Component {
     let { legal, hideDisclaimer, transcriptHtml } = this.props
     const creditsId = getKey()
 
+    const creditsButton = this.state.showCredits ? (
+      <NavItemActiveButton
+        aria-controls={creditsId}
+        type="button"
+        onClick={this.toggleCredits}
+        aria-expanded={this.state.showCredits}
+      >
+        Credits
+      </NavItemActiveButton>
+    ) : (
+      <NavItemButton
+        aria-controls={creditsId}
+        type="button"
+        onClick={this.toggleCredits}
+        aria-expanded={this.state.showCredits}
+      >
+        Credits
+      </NavItemButton>
+    );
+
     const disclaimerId = getKey()
     const disclaimerElement = hideDisclaimer
       ? null
       : this.renderDisclaimer(legal.disclaimerText, disclaimerId)
     const disclaimerButton = hideDisclaimer ? null : (
-      <li>
-        {this.state.showDisclaimer ? (
+      this.state.showDisclaimer ? (
           <NavItemActiveButton
             aria-controls={disclaimerId}
             type="button"
@@ -349,8 +365,7 @@ class MediaCredits extends Component {
           >
             Disclaimer
           </NavItemButton>
-        )}
-      </li>
+        )
     )
 
     const transcriptId = getKey()
@@ -428,31 +443,11 @@ class MediaCredits extends Component {
     return (
       <DivWrapper>
         <DivNavWrapper>
-          <NavUl>
+          <NavButtonsRow>
             {transcriptButton}
             {disclaimerButton}
-            <li>
-              {this.state.showCredits ? (
-                <NavItemActiveButton
-                  aria-controls={creditsId}
-                  type="button"
-                  onClick={this.toggleCredits}
-                  aria-expanded={this.state.showCredits}
-                >
-                  Credits
-                </NavItemActiveButton>
-              ) : (
-                <NavItemButton
-                  aria-controls={creditsId}
-                  type="button"
-                  onClick={this.toggleCredits}
-                  aria-expanded={this.state.showCredits}
-                >
-                  Credits
-                </NavItemButton>
-              )}
-            </li>
-          </NavUl>
+            {creditsButton}
+          </NavButtonsRow>
         </DivNavWrapper>
         {transcriptElement}
         {disclaimerElement}

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -307,9 +307,7 @@ class MediaCredits extends Component {
 
   renderCredits(id) {
     const { asOfDate, credits } = this.props
-    let template = ''
-
-    template = this.state.showCredits ? (
+    return this.state.showCredits ? (
       <Credits
         role="region"
         id={id}
@@ -321,8 +319,6 @@ class MediaCredits extends Component {
     ) : (
       ''
     )
-
-    return template
   }
 
   render() {
@@ -340,11 +336,17 @@ class MediaCredits extends Component {
             aria-controls={disclaimerId}
             type="button"
             onClick={this.toggleDisclaimer}
+            aria-expanded={this.state.showDisclaimer}
           >
             Disclaimer
           </NavItemActiveButton>
         ) : (
-          <NavItemButton aria-controls={disclaimerId} type="button" onClick={this.toggleDisclaimer}>
+          <NavItemButton 
+            aria-controls={disclaimerId} 
+            type="button" 
+            onClick={this.toggleDisclaimer}
+            aria-expanded={this.state.showDisclaimer}
+          >
             Disclaimer
           </NavItemButton>
         )}
@@ -426,8 +428,8 @@ class MediaCredits extends Component {
     return (
       <DivWrapper>
         <DivNavWrapper>
-          {transcriptButton}
           <NavUl>
+            {transcriptButton}
             {disclaimerButton}
             <li>
               {this.state.showCredits ? (

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -70,7 +70,13 @@ const NavButton = styled.button`
   color: #017acd;
   border: none;
   background: transparent;
+  border-radius: 1px;
 
+  &:focus, 
+  &:hover {
+    outline: 2px dotted #000;
+  }
+  
   padding: 5px 15px;
   &:disabled {
     padding: 0;
@@ -81,14 +87,7 @@ const NavButton = styled.button`
     outline: none;
     cursor: default;
   }
-
-  background: #f0f1f4;
-  border-radius: 1px;
   
-  &:focus, 
-  &:hover {
-    outline: 2px dotted #000;
-  }
 
   @media screen and (-ms-high-contrast: active) {
     background: #fff;

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -98,6 +98,7 @@ const NavButton = styled.button`
   @media screen and (-ms-high-contrast: black-on-white) {
     background: #000;
     color: #fff;
+    outline: 2px dotted #fff;
   }
 `
 
@@ -174,7 +175,6 @@ class MediaCredits extends Component {
     const { asOfDate, credits } = this.props
     return this.state.showCredits ? (
       <Credits
-        className=""
         role="region"
         id={id}
         aria-live="polite"

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -126,16 +126,6 @@ class MediaCredits extends Component {
     })
   }
 
-  toggleTranscript() {
-    const newState = !this.state.showTranscript
-
-    this.setState({
-      showDisclaimer: false,
-      showCredits: false,
-      showTranscript: newState,
-    })
-  }
-
   toggleCredits() {
     const newState = !this.state.showCredits
 
@@ -143,6 +133,16 @@ class MediaCredits extends Component {
       showDisclaimer: false,
       showCredits: newState,
       showTranscript: false,
+    })
+  }
+
+  toggleTranscript() {
+    const newState = !this.state.showTranscript
+
+    this.setState({
+      showDisclaimer: false,
+      showCredits: false,
+      showTranscript: newState,
     })
   }
 

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -76,7 +76,7 @@ const NavButton = styled.button`
   &:hover {
     outline: 2px dotted #000;
   }
-  
+
   padding: 5px 15px;
   &:disabled {
     padding: 0;
@@ -205,6 +205,8 @@ class MediaCredits extends Component {
     const disclaimerElement = hideDisclaimer
       ? null
       : this.renderDisclaimer(legal.disclaimerText, disclaimerId)
+
+    // if hideDisclaimer prop was true, disclaimerElement will be null therefore no button
     const disclaimerButton = disclaimerElement ? (
       <NavButton
         aria-controls={disclaimerId}

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -58,89 +58,6 @@ const NavRightWrapper = styled.div`
   justify-content: flex-end;
 `
 
-const NavItemButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.8em;
-  margin: 5px 2px 0;
-  padding: 10px 15px;
-  color: #017acd;
-  border: none;
-  background: transparent;
-
-  &:focus,
-  &:hover {
-    color: #015c9a;
-    cursor: pointer;
-    outline: 2px solid #000;
-  }
-
-  @media screen and (-ms-high-contrast: active) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #fff;
-    }
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #000;
-    }
-  }
-`
-
-const NavItemActiveButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.8em;
-  margin: 5px 2px 0;
-  padding: 10px 15px;
-  color: #017acd;
-  border: none;
-  background: transparent;
-
-  &:focus,
-  &:hover {
-    color: #015c9a;
-    cursor: pointer;
-    outline: 2px solid #000;
-  }
-
-  @media screen and (-ms-high-contrast: active) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #fff;
-    }
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #000;
-    }
-  }
-
-  background: #f0f1f4;
-  border-radius: 1px;
-
-  @media screen and (-ms-high-contrast: active) {
-    background: #fff;
-    color: #000;
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    background: #000;
-    color: #fff;
-  }
-`
-
 const NavButton = styled.button`
   box-sizing: border-box;
   display: flex;
@@ -290,7 +207,7 @@ class MediaCredits extends Component {
     const disclaimerElement = hideDisclaimer
       ? null
       : this.renderDisclaimer(legal.disclaimerText, disclaimerId)
-    const disclaimerButton = (
+    const disclaimerButton = disclaimerElement ? (
       <NavButton
         aria-controls={disclaimerId}
         type="button"
@@ -299,13 +216,13 @@ class MediaCredits extends Component {
       >
         Disclaimer
       </NavButton>
-    )
+    ) : ( '' );
 
     const transcriptId = getKey()
     const transcriptElement = transcriptHtml
       ? this.renderTranscript(transcriptHtml, transcriptId)
       : null
-    const transcriptButton = (
+    const transcriptButton =  transcriptHtml ? (
       <NavButton
         aria-controls={transcriptId}
         type="button"
@@ -331,7 +248,17 @@ class MediaCredits extends Component {
           </svg>
         </IconSpan> 
           <span>Transcript</span>
-        </NavButton>
+      </NavButton>
+    ) : (
+      <NavButton
+        tabIndex="-1"
+        disabled
+        type="button"
+        role="presentation"
+        aria-hidden="true"
+      >
+        {' '}
+      </NavButton>
     )
 
     return (

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -162,10 +162,9 @@ class MediaCredits extends Component {
   renderDisclaimer(text, id) {
     return this.state.showDisclaimer ? (
       <p
-        role="region" 
+        role="region"
         id={id} 
-        aria-live="polite" 
-        aria-atomic="false">
+        aria-live="polite">
         {text}
       </p>
     ) : null

--- a/src/MediaCredits/index.js
+++ b/src/MediaCredits/index.js
@@ -25,9 +25,11 @@ const DivNavWrapper = styled.div`
 `
 
 const NavButtonsRow = styled.div`
+  width: 100%;
   margin: 0;
   padding: 0;
   display: flex;
+  justify-content: space-between;
 
   @media screen and (-ms-high-contrast: active) {
     background: #fff;
@@ -48,6 +50,12 @@ const IconSpan = styled.span`
   & svg {
     width: 100%;
   }
+`
+
+const NavRightWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: flex-end;
 `
 
 const NavItemButton = styled.button`
@@ -133,7 +141,7 @@ const NavItemActiveButton = styled.button`
   }
 `
 
-const NavTranscriptItemButton = styled.button`
+const NavButton = styled.button`
   box-sizing: border-box;
   display: flex;
   flex-wrap: nowrap;
@@ -146,76 +154,11 @@ const NavTranscriptItemButton = styled.button`
   border: none;
   background: transparent;
 
-  &:focus,
-  &:hover {
-    color: #015c9a;
-    cursor: pointer;
-    outline: 2px solid #000;
-  }
-
-  @media screen and (-ms-high-contrast: active) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #fff;
-    }
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #000;
-    }
-  }
-
   padding: 5px 15px;
   &:disabled {
     padding: 0;
   }
-  &:disabled:focus,
-  &:disabled:hover {
-    outline: none;
-    cursor: default;
-  }
-`
-
-const NavTranscriptItemActiveButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.8em;
-  margin: 5px 2px 0;
-  padding: 10px 15px;
-  color: #017acd;
-  border: none;
-  background: transparent;
-
-  &:focus,
-  &:hover {
-    color: #015c9a;
-    cursor: pointer;
-    outline: 2px solid #000;
-  }
-
-  @media screen and (-ms-high-contrast: active) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #fff;
-    }
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    &:focus,
-    &:hover {
-      outline: 2px solid #000;
-    }
-  }
-
-  padding: 5px 15px;
-  &:disabled {
-    padding: 0;
-  }
+  
   &:disabled:focus,
   &:disabled:hover {
     outline: none;
@@ -224,6 +167,11 @@ const NavTranscriptItemActiveButton = styled.button`
 
   background: #f0f1f4;
   border-radius: 1px;
+  
+  &:focus, 
+  &:hover {
+    outline: 2px dotted #000;
+  }
 
   @media screen and (-ms-high-contrast: active) {
     background: #fff;
@@ -261,16 +209,6 @@ class MediaCredits extends Component {
     })
   }
 
-  toggleCredits() {
-    const newState = !this.state.showCredits
-
-    this.setState({
-      showDisclaimer: false,
-      showCredits: newState,
-      showTranscript: false,
-    })
-  }
-
   toggleTranscript() {
     const newState = !this.state.showTranscript
 
@@ -278,6 +216,16 @@ class MediaCredits extends Component {
       showDisclaimer: false,
       showCredits: false,
       showTranscript: newState,
+    })
+  }
+
+  toggleCredits() {
+    const newState = !this.state.showCredits
+
+    this.setState({
+      showDisclaimer: false,
+      showCredits: newState,
+      showTranscript: false,
     })
   }
 
@@ -296,7 +244,11 @@ class MediaCredits extends Component {
 
   renderDisclaimer(text, id) {
     return this.state.showDisclaimer ? (
-      <p role="region" id={id} aria-live="polite">
+      <p
+        role="region" 
+        id={id} 
+        aria-live="polite" 
+        aria-atomic="false">
         {text}
       </p>
     ) : null
@@ -306,6 +258,7 @@ class MediaCredits extends Component {
     const { asOfDate, credits } = this.props
     return this.state.showCredits ? (
       <Credits
+        className=""
         role="region"
         id={id}
         aria-live="polite"
@@ -322,131 +275,74 @@ class MediaCredits extends Component {
     let { legal, hideDisclaimer, transcriptHtml } = this.props
     const creditsId = getKey()
 
-    const creditsButton = this.state.showCredits ? (
-      <NavItemActiveButton
+    const creditsButton = (
+      <NavButton
         aria-controls={creditsId}
         type="button"
         onClick={this.toggleCredits}
         aria-expanded={this.state.showCredits}
       >
         Credits
-      </NavItemActiveButton>
-    ) : (
-      <NavItemButton
-        aria-controls={creditsId}
-        type="button"
-        onClick={this.toggleCredits}
-        aria-expanded={this.state.showCredits}
-      >
-        Credits
-      </NavItemButton>
-    );
+      </NavButton>
+    )
 
     const disclaimerId = getKey()
     const disclaimerElement = hideDisclaimer
       ? null
       : this.renderDisclaimer(legal.disclaimerText, disclaimerId)
-    const disclaimerButton = hideDisclaimer ? null : (
-      this.state.showDisclaimer ? (
-          <NavItemActiveButton
-            aria-controls={disclaimerId}
-            type="button"
-            onClick={this.toggleDisclaimer}
-            aria-expanded={this.state.showDisclaimer}
-          >
-            Disclaimer
-          </NavItemActiveButton>
-        ) : (
-          <NavItemButton 
-            aria-controls={disclaimerId} 
-            type="button" 
-            onClick={this.toggleDisclaimer}
-            aria-expanded={this.state.showDisclaimer}
-          >
-            Disclaimer
-          </NavItemButton>
-        )
+    const disclaimerButton = (
+      <NavButton
+        aria-controls={disclaimerId}
+        type="button"
+        onClick={this.toggleDisclaimer}
+        aria-expanded={this.state.showDisclaimer}
+      >
+        Disclaimer
+      </NavButton>
     )
 
     const transcriptId = getKey()
     const transcriptElement = transcriptHtml
       ? this.renderTranscript(transcriptHtml, transcriptId)
       : null
-    const transcriptButton = transcriptHtml ? (
-      this.showTranscript ? (
-        <NavTranscriptItemActiveButton
-          aria-controls={transcriptId}
-          type="button"
-          onClick={this.toggleTranscript}
-          aria-expanded={this.state.showTranscript}
-        >
-          <IconSpan>
-            <svg
-              role="presentation"
-              focusable="false"
-              width="18"
-              height="22"
-              viewBox="0 0 18 22"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g>
-                <path d="M1.528 1.634h14.944v18.732H1.528V1.634z" fill="#017acd" />
-                <path
-                  d="M3.728 9.646h10.59v2.26H3.728v-2.26zm0-4.355h10.59v2.26H3.728V5.29zm-.073 9.036h6.403v2.404H3.655v-2.404z"
-                  fill="#fff"
-                />
-              </g>
-            </svg>
-          </IconSpan>
-          <span>Transcript</span>
-        </NavTranscriptItemActiveButton>
-      ) : (
-        <NavTranscriptItemButton
-          aria-controls={transcriptId}
-          type="button"
-          onClick={this.toggleTranscript}
-          aria-expanded={this.state.showTranscript}
-        >
-          <IconSpan>
-            <svg
-              role="presentation"
-              focusable="false"
-              width="18"
-              height="22"
-              viewBox="0 0 18 22"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g>
-                <path d="M1.528 1.634h14.944v18.732H1.528V1.634z" fill="#017acd" />
-                <path
-                  d="M3.728 9.646h10.59v2.26H3.728v-2.26zm0-4.355h10.59v2.26H3.728V5.29zm-.073 9.036h6.403v2.404H3.655v-2.404z"
-                  fill="#fff"
-                />
-              </g>
-            </svg>
-          </IconSpan>
-          <span>Transcript</span>
-        </NavTranscriptItemButton>
-      )
-    ) : (
-      <NavTranscriptItemButton
-        tabIndex="-1"
-        disabled
+    const transcriptButton = (
+      <NavButton
+        aria-controls={transcriptId}
         type="button"
-        role="presentation"
-        aria-hidden="true"
-      >
-        {' '}
-      </NavTranscriptItemButton>
+        onClick={this.toggleTranscript}
+        aria-expanded={this.state.showTranscript}
+        >
+          <IconSpan>
+            <svg
+            role="presentation"
+            focusable="false"
+            width="18"
+            height="22"
+            viewBox="0 0 18 22"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path d="M1.528 1.634h14.944v18.732H1.528V1.634z" fill="#017acd" />
+              <path
+                d="M3.728 9.646h10.59v2.26H3.728v-2.26zm0-4.355h10.59v2.26H3.728V5.29zm-.073 9.036h6.403v2.404H3.655v-2.404z"
+                fill="#fff"
+              />
+            </g>
+          </svg>
+        </IconSpan> 
+          <span>Transcript</span>
+        </NavButton>
     )
 
     return (
       <DivWrapper>
         <DivNavWrapper>
           <NavButtonsRow>
-            {transcriptButton}
-            {disclaimerButton}
-            {creditsButton}
+              {transcriptButton}
+            <NavRightWrapper>
+              {disclaimerButton}
+              {creditsButton}
+            </NavRightWrapper>
           </NavButtonsRow>
         </DivNavWrapper>
         {transcriptElement}


### PR DESCRIPTION
there were some a11y implications around the focus state when some of these button elements were selected. There didn't seem to be much value in overriding the native active/focussed element flow by providing different buttons based on state, and it was causing the focus state to be lost on every button exept the transcript.

The markup is a bit more simplified now, and although not perfect a11y order, we now have consistent access to the content panels by using the keyboard and a screen reader.

Also some small enhancements like dots instead of solid border etc.